### PR TITLE
Add Clouds and Branches input normalizations

### DIFF
--- a/src/Branches.cpp
+++ b/src/Branches.cpp
@@ -69,7 +69,11 @@ static void computeChannel(const float *in, const float *p, float threshold, flo
 
 void Branches::step() {
 	computeChannel(inputs[IN1_INPUT], inputs[P1_INPUT], params[THRESHOLD1_PARAM], params[MODE1_PARAM], &lastGate[0], &outcome[0], outputs[OUT1A_OUTPUT], outputs[OUT1B_OUTPUT], &light[0]);
-	computeChannel(inputs[IN2_INPUT], inputs[P2_INPUT], params[THRESHOLD2_PARAM], params[MODE2_PARAM], &lastGate[1], &outcome[1], outputs[OUT2A_OUTPUT], outputs[OUT2B_OUTPUT], &light[1]);
+
+	if(inputs[IN2_INPUT])
+		computeChannel(inputs[IN2_INPUT], inputs[P2_INPUT], params[THRESHOLD2_PARAM], params[MODE2_PARAM], &lastGate[1], &outcome[1], outputs[OUT2A_OUTPUT], outputs[OUT2B_OUTPUT], &light[1]);
+	else
+		computeChannel(inputs[IN1_INPUT], inputs[P2_INPUT], params[THRESHOLD2_PARAM], params[MODE2_PARAM], &lastGate[1], &outcome[1], outputs[OUT2A_OUTPUT], outputs[OUT2B_OUTPUT], &light[1]);
 }
 
 

--- a/src/Clouds.cpp
+++ b/src/Clouds.cpp
@@ -77,7 +77,11 @@ void Clouds::step() {
 	if (!inputBuffer.full()) {
 		Frame<2> inputFrame;
 		inputFrame.samples[0] = getf(inputs[IN_L_INPUT]) * params[IN_GAIN_PARAM] / 5.0;
-		inputFrame.samples[1] = getf(inputs[IN_R_INPUT]) * params[IN_GAIN_PARAM] / 5.0;
+		if(inputs[IN_R_INPUT])
+			inputFrame.samples[1] = getf(inputs[IN_R_INPUT]) * params[IN_GAIN_PARAM] / 5.0;
+		else
+			inputFrame.samples[1] = getf(inputs[IN_L_INPUT]) * params[IN_GAIN_PARAM] / 5.0;
+
 		inputBuffer.push(inputFrame);
 	}
 


### PR DESCRIPTION
The inputs on Clouds and Branches now act as they do on their hardware counterparts. The Clouds code could potentially be more efficient. I think something like

```
const float leftSample = getf(inputs[IN_L_INPUT]);
const float rightSample = inputs[IN_R_INPUT] ? getf(inputs[IN_R_INPUT]) : leftSample;
```

could work just to avoid the extra getf calls.