### PR TITLE
Normal Warps' level inputs to 5v and make pots attenuate to match hardware and manual

### DIFF
--- a/src/Warps.cpp
+++ b/src/Warps.cpp
@@ -63,8 +63,8 @@ struct Warps : Module {
 		if (++frame >= 60) {
 			frame = 0;
 
-			p->channel_drive[0] = clamp(params[LEVEL1_PARAM].getValue() + inputs[LEVEL1_INPUT].getVoltage() / 5.0f, 0.0f, 1.0f);
-			p->channel_drive[1] = clamp(params[LEVEL2_PARAM].getValue() + inputs[LEVEL2_INPUT].getVoltage() / 5.0f, 0.0f, 1.0f);
+			p->channel_drive[0] = clamp(params[LEVEL1_PARAM].getValue() * inputs[LEVEL1_INPUT].getNormalVoltage(5.0f) / 5.0f, 0.0f, 1.0f);
+			p->channel_drive[1] = clamp(params[LEVEL2_PARAM].getValue() * inputs[LEVEL2_INPUT].getNormalVoltage(5.0f) / 5.0f, 0.0f, 1.0f);
 			p->modulation_algorithm = clamp(params[ALGORITHM_PARAM].getValue() / 8.0f + inputs[ALGORITHM_INPUT].getVoltage() / 5.0f, 0.0f, 1.0f);
 
 			{


### PR DESCRIPTION
Note that the level 1 pot still operate additively with level 1 cv for controlling the frequency of the internal oscillator as that is handled separately on line 84.