### PR TITLE
Fix maybe uninitialized warnings

### DIFF
--- a/src/Shelves.cpp
+++ b/src/Shelves.cpp
@@ -119,7 +119,7 @@ struct Shelves : Module {
 		int channels = std::max(inputs[IN_INPUT].getChannels(), 1);
 
 		// Reuse the same frame object for multiple engines because the params aren't touched.
-		shelves::ShelvesEngine::Frame frame;
+		shelves::ShelvesEngine::Frame frame = {};
 		frame.pre_gain = preGain;
 
 		frame.hs_freq_knob = rescale(params[HS_FREQ_PARAM].getValue(), freqMin, freqMax, 0.f, 1.f);

--- a/src/Streams.cpp
+++ b/src/Streams.cpp
@@ -275,7 +275,7 @@ struct Streams : Module {
 
 		// Reuse the same frame object for multiple engines because the params
 		// aren't touched.
-		streams::StreamsEngine::Frame frame;
+		streams::StreamsEngine::Frame frame = {};
 
 		frame.ch1.shape_knob          = params[CH1_SHAPE_PARAM]    .getValue();
 		frame.ch1.mod_knob            = params[CH1_MOD_PARAM]      .getValue();


### PR DESCRIPTION
These were detected by GCC with LTO:
```
AudibleInstruments/src/Shelves.cpp: In member function 'process':
../src/Rack/include/engine/Port.hpp:43:21: error: 'frame.p2_lp_out' may be used uninitialized in this function [-Werror=maybe-uninitialized]
AudibleInstruments/src/Shelves.cpp:122:33: note: 'frame.p2_lp_out' was declared here
../src/Rack/include/engine/Port.hpp:43:21: error: 'frame.p2_bp_out' may be used uninitialized in this function [-Werror=maybe-uninitialized]
AudibleInstruments/src/Shelves.cpp:122:33: note: 'frame.p2_bp_out' was declared here
../src/Rack/include/engine/Port.hpp:43:21: error: 'frame.p2_hp_out' may be used uninitialized in this function [-Werror=maybe-uninitialized]
AudibleInstruments/src/Shelves.cpp:122:33: note: 'frame.p2_hp_out' was declared here
```

Not all of the variables are initialized in the constructor, so seems safer to force it with `= {}`.
